### PR TITLE
Little simpler

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -1,17 +1,11 @@
 package bus
 
-type Consumer interface {
+type ConsumerBus interface {
 	Msg() (msg []byte, done bool, err error)
 	Stop() error
 }
 
-type Producer interface {
-	Send(topic string, msg []byte) error
-	Stop() error
-}
-
-type Bus interface {
-	Msg() (msg []byte, done bool, err error)
+type ProducerBus interface {
 	Send(topic string, msg []byte) error
 	Stop() error
 }

--- a/bus/nop/README.md
+++ b/bus/nop/README.md
@@ -1,0 +1,5 @@
+# Nop Bus 
+
+Nop bus provides a no-operation producer and consumer mostly
+for testing.
+

--- a/bus/nop/consumer.go
+++ b/bus/nop/consumer.go
@@ -1,0 +1,62 @@
+package nop
+
+import "errors"
+
+// FakeMsg can be set to control the returned
+// Msg() msg value.
+var FakeMsg = []byte(`{"type":"test","info":"test-info","created":"2017-01-01T00:00:01Z"}`)
+
+// NewConsumer returns a nop (no-operation) Consumer.
+// Will return *Consumer == nil and err != nil
+// if mock == "init_err".
+func NewConsumer(mock string) (*Consumer, error) {
+	if mock == "init_err" {
+		return nil, errors.New(mock)
+	}
+
+	return &Consumer{mock}, nil
+}
+
+// Consumer is a no-operation consumer. It
+// does not do anything and is useful for mocking.
+type Consumer struct {
+	// Mock can be set in order to
+	// mock various return scenarios.
+	//
+	// Supported Values:
+	// - "init_err" - returns err on NewConsumer
+	// - "err" - every method returns an error
+	// - "msg_err" - returns err on Consumer.Msg() call.
+	// - "msg_done" - returns a nil task message done=true on Consumer.Msg() call.
+	// - "msg_msg_done" - returns a non-nil task message and done=true Consumer.Msg() call.
+	// - "stop_err" - returns err on Stop() method call
+	Mock string
+}
+
+// Msg will always return a fake task message unless err != nil
+// or Mock == "msg_done".
+func (c *Consumer) Msg() (msg []byte, done bool, err error) {
+	if c.Mock == "msg_err" {
+		return msg, done, errors.New(c.Mock)
+	}
+
+	if c.Mock == "msg_done" {
+		return msg, true, err
+	}
+
+	if c.Mock == "msg_msg_done" {
+		done = true
+	}
+
+	// set fake msg
+	msg = FakeMsg
+	return msg, done, err
+}
+
+// Stop is a mock consumer Stop method.
+func (c *Consumer) Stop() error {
+	if c.Mock == "stop_err" {
+		return errors.New(c.Mock)
+	}
+	return nil
+}

--- a/bus/nop/consumer_test.go
+++ b/bus/nop/consumer_test.go
@@ -1,0 +1,170 @@
+package nop
+
+import (
+	"fmt"
+)
+
+func ExampleNewConsumer() {
+	// showing:
+	// - non-nil consumer without err
+
+	// non-nil consumer
+	// using a non-supported mock string just
+	// to demonstrate that Mock property is
+	// set correctly.
+	c, err := NewConsumer("mock_string")
+	if c == nil {
+		return
+	}
+	fmt.Println(c.Mock) // output: mock_string
+	fmt.Println(err)    // output: <nil>
+
+	// Output:
+	// mock_string
+	// <nil>
+}
+
+func ExampleNewConsumerErr() {
+	// showing:
+	// - nil consumer with err
+
+	// nil consumer with err
+	c, err := NewConsumer("init_err")
+	if err == nil {
+		return
+	}
+
+	fmt.Println(c)           // output: <nil>
+	fmt.Println(err.Error()) // output: init_err
+
+	// Output:
+	// <nil>
+	// init_err
+}
+
+func ExampleConsumer_Msg() {
+	// showing:
+	// - Msg msg standard response
+
+	c, _ := NewConsumer("")
+	if c == nil {
+		return
+	}
+	msg, done, err := c.Msg()
+	fmt.Println(string(msg)) // output: {"type":"test","info":"test-info","created":"2017-01-01T00:00:01Z"}
+	fmt.Println(done)        // output: false
+	fmt.Println(err)         // output: <nil>
+
+	// Output:
+	// {"type":"test","info":"test-info","created":"2017-01-01T00:00:01Z"}
+	// false
+	// <nil>
+}
+
+func ExampleConsumer_MsgFake() {
+	// showing:
+	// - Msg msg custom fake response
+
+	c, _ := NewConsumer("")
+	if c == nil {
+		return
+	}
+	origMsg := FakeMsg
+	FakeMsg = []byte("fake msg")
+	msg, done, err := c.Msg()
+	fmt.Println(string(msg)) // output: fake msg
+	fmt.Println(done)        // output: false
+	fmt.Println(err)         // output: <nil>
+
+	FakeMsg = origMsg // return to original state
+
+	// Output:
+	// fake msg
+	// false
+	// <nil>
+}
+
+func ExampleConsumer_MsgDone() {
+	// showing:
+	// - Msg returns done == true
+
+	c, _ := NewConsumer("msg_done")
+	if c == nil {
+		return
+	}
+	msg, done, err := c.Msg()
+	fmt.Println(string(msg)) // output:
+	fmt.Println(done)        // output: true
+	fmt.Println(err)         // output: <nil>
+
+	// Output:
+	//
+	// true
+	// <nil>
+}
+
+func ExampleConsumer_MsgMsgDone() {
+	// showing:
+	// - Msg returns non-nil msg and done == true
+
+	c, _ := NewConsumer("msg_msg_done")
+	if c == nil {
+		return
+	}
+	msg, done, err := c.Msg()
+	fmt.Println(string(msg)) // output: {"type":"test","info":"test-info","created":"2017-01-01T00:00:01Z"}
+	fmt.Println(done)        // output: true
+	fmt.Println(err)         // output: <nil>
+
+	// Output:
+	// {"type":"test","info":"test-info","created":"2017-01-01T00:00:01Z"}
+	// true
+	// <nil>
+}
+
+func ExampleConsumer_MsgErr() {
+	// showing:
+	// - Msg err != nil
+
+	c, _ := NewConsumer("msg_err")
+	if c == nil {
+		return
+	}
+	msg, done, err := c.Msg()
+	fmt.Println(string(msg)) // output:
+	fmt.Println(done)        // output: fals
+	fmt.Println(err)         // output: msg_err
+
+	// Output:
+	//
+	// false
+	// msg_err
+}
+
+func ExampleConsumer_Stop() {
+	// showing:
+	// - Stop method returns nil error
+
+	c, _ := NewConsumer("")
+	if c == nil {
+		return
+	}
+	fmt.Println(c.Stop()) // output: <nil>
+
+	// Output:
+	// <nil>
+}
+
+func ExampleConsumer_StopErr() {
+	// showing:
+	// - Stop method returns nil error
+
+	c, _ := NewConsumer("stop_err")
+	if c == nil {
+		return
+	}
+	fmt.Println(c.Stop()) // output: stop_err
+
+	// Output:
+	// stop_err
+}

--- a/bus/nop/producer.go
+++ b/bus/nop/producer.go
@@ -1,0 +1,43 @@
+package nop
+
+import "errors"
+
+// NewProducer returns a nop (no-operation) Producer.
+// Will return *Producer == nil and err != nil
+// if mock == "init_err".
+func NewProducer(mock string) (*Producer, error) {
+	if mock == "init_err" {
+		return nil, errors.New(mock)
+	}
+
+	return &Producer{mock}, nil
+}
+
+// Producer is a no-operation consumer. It
+// does not do anything and is useful for mocking.
+type Producer struct {
+	// Mock can be set in order to
+	// mock various return scenarios.
+	//
+	// Supported Values:
+	// - "init_err" - returns err on NewProducer
+	// - "err" - every method returns an error
+	// - "send_err" - returns err when Producer.Send() is called.
+	// - "stop_err" - returns err on Stop() method call
+	Mock string
+}
+
+func (p *Producer) Send(topic string, msg []byte) error {
+	if p.Mock == "send_err" {
+		return errors.New(p.Mock)
+	}
+	return nil
+}
+
+// Stop is a mock producer Stop method.
+func (p *Producer) Stop() error {
+	if p.Mock == "stop_err" {
+		return errors.New(p.Mock)
+	}
+	return nil
+}

--- a/bus/nop/producer_test.go
+++ b/bus/nop/producer_test.go
@@ -1,0 +1,97 @@
+package nop
+
+import "fmt"
+
+func ExampleNewProducer() {
+	// showing:
+	// - non-nil producer without err
+
+	// non-nil producer
+	// using a non-supported mock string just
+	// to demonstrate that Mock property is
+	// set correctly.
+	p, err := NewProducer("mock_string")
+	if p == nil {
+		return
+	}
+	fmt.Println(p.Mock) // output: mock_string
+	fmt.Println(err)    // output: <nil>
+
+	// Output:
+	// mock_string
+	// <nil>
+}
+
+func ExampleNewProducerErr() {
+	// showing:
+	// - nil producer with err
+
+	// nil producer with err
+	p, err := NewProducer("init_err")
+	if err == nil {
+		return
+	}
+
+	fmt.Println(p)           // output: <nil>
+	fmt.Println(err.Error()) // output: init_err
+
+	// Output:
+	// <nil>
+	// init_err
+}
+
+func ExampleProducer_Send() {
+	// showing:
+	// - Send method returns nil error
+
+	p, _ := NewProducer("")
+	if p == nil {
+		return
+	}
+	fmt.Println(p.Send("test-topic", []byte("test-msg"))) // output: <nil>
+
+	// Output:
+	// <nil>
+}
+
+func ExampleProducer_SendErr() {
+	// showing:
+	// - Send method returns non-nil error
+
+	p, _ := NewProducer("send_err")
+	if p == nil {
+		return
+	}
+	fmt.Println(p.Send("test-topic", []byte("test-msg"))) // output: send_err
+
+	// Output:
+	// send_err
+}
+
+func ExampleProducer_Stop() {
+	// showing:
+	// - Stop method returns nil error
+
+	p, _ := NewProducer("")
+	if p == nil {
+		return
+	}
+	fmt.Println(p.Stop()) // output: <nil>
+
+	// Output:
+	// <nil>
+}
+
+func ExampleProducer_StopErr() {
+	// showing:
+	// - Stop method returns nil error
+
+	p, _ := NewProducer("stop_err")
+	if p == nil {
+		return
+	}
+	fmt.Println(p.Stop()) // output: stop_err
+
+	// Output:
+	// stop_err
+}

--- a/bus/nsq/consumer_test.go
+++ b/bus/nsq/consumer_test.go
@@ -62,27 +62,27 @@ var (
 func TestNewConsumer(t *testing.T) {
 	// turn off nsq client logging
 	//logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 	// Logger:       logger,
 	// NSQdAddrs: []string{"localhost:4150"},
 	// LookupdAddrs: []string{"localhost:4160"},
 	}
 
-	lc, err := NewLazyConsumer("", "", conf)
+	c, err := NewConsumer("", "", opt)
 	if err == nil {
 		t.Fatal("err should not be nil")
 	}
 
 	// consumer is nil
-	if lc != nil {
+	if c != nil {
 		t.Error("consumer should be nil")
 	}
 }
 
-func TestLazyConsumer_ConnectNoTopic(t *testing.T) {
+func TestConsumer_ConnectNoTopic(t *testing.T) {
 	// turn off nsq client logging
 	//logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 	// Logger:       logger,
 	// NSQdAddrs: []string{"localhost:4150"},
 	// LookupdAddrs: []string{"localhost:4160"},
@@ -90,7 +90,7 @@ func TestLazyConsumer_ConnectNoTopic(t *testing.T) {
 	topic := ""
 	channel := "testchannel"
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 
 	// err is not nil - invalid topic name
 	if err == nil {
@@ -98,15 +98,15 @@ func TestLazyConsumer_ConnectNoTopic(t *testing.T) {
 	}
 
 	// consumer is nil
-	if lc != nil {
+	if c != nil {
 		t.Error("consumer should be nil")
 	}
 }
 
-func TestLazyConsumer_ConnectNoChannel(t *testing.T) {
+func TestConsumer_ConnectNoChannel(t *testing.T) {
 	// turn off nsq client logging
 	//logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 	// Logger:       logger,
 	// NSQdAddrs: []string{"localhost:4150"},
 	// LookupdAddrs: []string{"localhost:4160"},
@@ -114,7 +114,7 @@ func TestLazyConsumer_ConnectNoChannel(t *testing.T) {
 	topic := "testtopic"
 	channel := ""
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 
 	// err is not nil - invalid channel name
 	if err == nil {
@@ -122,15 +122,15 @@ func TestLazyConsumer_ConnectNoChannel(t *testing.T) {
 	}
 
 	// consumer is nil
-	if lc != nil {
+	if c != nil {
 		t.Error("consumer should be nil")
 	}
 }
 
-func TestLazyConsumer_Connect(t *testing.T) {
+func TestConsumer_Connect(t *testing.T) {
 	// turn off nsq client logging
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 		Logger: logger,
 		// NSQdAddrs: []string{"localhost:4150"},
 		// LookupdAddrs: []string{"localhost:4160"},
@@ -138,7 +138,7 @@ func TestLazyConsumer_Connect(t *testing.T) {
 	topic := "testtopic"
 	channel := "testchannel"
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 
 	// err - nil
 	if err != nil {
@@ -146,26 +146,26 @@ func TestLazyConsumer_Connect(t *testing.T) {
 	}
 
 	// consumer - not nil
-	if lc == nil {
+	if c == nil {
 		t.Fatal("consumer should not be nil")
 	}
 
-	// lc.consumer - not nil
-	if lc.consumer == nil {
+	// c.consumer - not nil
+	if c.consumer == nil {
 		t.Fatal("nsq consumer should not be nil")
 	}
 
 	// stop - no error
-	if err := lc.Stop(); err != nil {
+	if err := c.Stop(); err != nil {
 		t.Fatalf("bad shutdown: %v\n", err)
 	}
 }
 
-func TestLazyConsumer_ConnectNSQdsBad(t *testing.T) {
+func TestConsumer_ConnectNSQdsBad(t *testing.T) {
 	// TEST BAD NSQD
 	// turn off nsq client logging
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 		Logger:    logger,
 		NSQdAddrs: []string{"localhost:4000"},
 		// LookupdAddrs: []string{"localhost:4160"},
@@ -173,7 +173,7 @@ func TestLazyConsumer_ConnectNSQdsBad(t *testing.T) {
 	topic := "testtopic"
 	channel := "testchannel"
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 
 	// err - not nil
 	if err == nil {
@@ -181,16 +181,16 @@ func TestLazyConsumer_ConnectNSQdsBad(t *testing.T) {
 	}
 
 	// consumer - nil
-	if lc != nil {
+	if c != nil {
 		t.Error("consumer should be nil")
 	}
 }
 
-func TestLazyConsumer_ConnectNSQds(t *testing.T) {
+func TestConsumer_ConnectNSQds(t *testing.T) {
 	// TEST GOOD NSQD
 	// turn off nsq client logging
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 		Logger:    logger,
 		NSQdAddrs: []string{"localhost:4150"},
 		// LookupdAddrs: []string{"localhost:4160"},
@@ -198,24 +198,24 @@ func TestLazyConsumer_ConnectNSQds(t *testing.T) {
 	topic := "testtopic"
 	channel := "testchannel"
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check nsq consumer (should not be nil)
-	if lc.consumer == nil {
+	if c.consumer == nil {
 		t.Errorf("nsq consumer should not be nil")
 	}
 
 	// check that consumer shuts down safely - even without
 	// successfully connecting
-	if err := lc.Stop(); err != nil {
+	if err := c.Stop(); err != nil {
 		t.Fatalf("bad shutdown: %v\n", err)
 	}
 }
 
-func TestLazyConsumer_ConnectLookupdsBad(t *testing.T) {
+func TestConsumer_ConnectLookupdsBad(t *testing.T) {
 	// TEST BAD LOOKUPD
 	// Note: nsq will not return an error if a connection to
 	// lookupd could not be made. It will instead keep trying
@@ -224,7 +224,7 @@ func TestLazyConsumer_ConnectLookupdsBad(t *testing.T) {
 
 	// turn off nsq client logging
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 		Logger: logger,
 		// NSQdAddrs: []string{"localhost:4150"},
 		LookupdAddrs: []string{"localhost:4000"}, // bad port
@@ -232,18 +232,18 @@ func TestLazyConsumer_ConnectLookupdsBad(t *testing.T) {
 	topic := "testtopic"
 	channel := "testchannel"
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check nsq consumer (should still be nil)
-	if lc.consumer == nil {
+	if c.consumer == nil {
 		t.Errorf("nsq consumer should not be nil")
 	}
 
 	// check that there are no connections (since it's not a valid port)
-	stats := lc.consumer.Stats()
+	stats := c.consumer.Stats()
 	expected := 0
 	if stats.Connections != expected {
 		t.Errorf("expected '%v' but got '%v'", expected, stats.Connections)
@@ -251,12 +251,12 @@ func TestLazyConsumer_ConnectLookupdsBad(t *testing.T) {
 
 	// check that consumer shuts down safely - even without
 	// successfully connecting
-	if err := lc.Stop(); err != nil {
+	if err := c.Stop(); err != nil {
 		t.Fatalf("bad shutdown: %v\n", err)
 	}
 }
 
-func TestLazyConsumer_ConnectLookupds(t *testing.T) {
+func TestConsumer_ConnectLookupds(t *testing.T) {
 	// TEST GOOD LOOKUPD
 	// Note: nsq will not return an error if a connection to
 	// lookupd could not be made. It will instead keep trying
@@ -265,7 +265,7 @@ func TestLazyConsumer_ConnectLookupds(t *testing.T) {
 
 	// turn off nsq client logging
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 		Logger: logger,
 		// NSQdAddrs: []string{"localhost:4150"},
 		LookupdAddrs: []string{"localhost:4161"}, // good port
@@ -273,18 +273,18 @@ func TestLazyConsumer_ConnectLookupds(t *testing.T) {
 	topic := "testtopic"
 	channel := "testchannel"
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check nsq consumer (should not be nil)
-	if lc.consumer == nil {
+	if c.consumer == nil {
 		t.Errorf("nsq consumer should not be nil")
 	}
 
 	// check that there are no connections (since it's not a valid port)
-	stats := lc.consumer.Stats()
+	stats := c.consumer.Stats()
 	expected := 1
 	if stats.Connections != expected {
 		t.Errorf("expected '%v' but got '%v'", expected, stats.Connections)
@@ -292,12 +292,12 @@ func TestLazyConsumer_ConnectLookupds(t *testing.T) {
 
 	// check that consumer shuts down safely - even without
 	// successfully connecting
-	if err := lc.Stop(); err != nil {
+	if err := c.Stop(); err != nil {
 		t.Fatalf("bad shutdown: %v\n", err)
 	}
 }
 
-func TestLazyConsumer_Msg(t *testing.T) {
+func TestConsumer_Msg(t *testing.T) {
 	// TEST MSG
 	//
 	// - Should not load any messages upon connecting
@@ -310,7 +310,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 
 	// turn off nsq client logging
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	opt := &Opt{
 		Logger: logger,
 		// NSQdAddrs: []string{"localhost:4150"},
 		LookupdAddrs: []string{"localhost:4161"}, // good port
@@ -321,13 +321,13 @@ func TestLazyConsumer_Msg(t *testing.T) {
 	msgCnt := 1000
 	AddTasks(topic, msgCnt)
 
-	lc, err := NewLazyConsumer(topic, channel, conf)
+	c, err := NewConsumer(topic, channel, opt)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// check that there is a connection
-	stats := lc.consumer.Stats()
+	stats := c.consumer.Stats()
 	expected := 1
 	if stats.Connections != expected {
 		t.Errorf("expected '%v' but got '%v'", expected, stats.Connections)
@@ -352,7 +352,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 	}
 
 	// get one message
-	b, _, err := lc.Msg()
+	b, _, err := c.Msg()
 	if err != nil {
 		t.Errorf("expected nil but got '%v'", err.Error())
 	}
@@ -366,7 +366,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 	<-tckr.C
 
 	// check that there is a connection
-	stats = lc.consumer.Stats()
+	stats = c.consumer.Stats()
 
 	// no messages finished
 	expected = 1
@@ -394,7 +394,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 	errCntGot := int64(0)
 	msgCntGot := int64(0)
 	for i := 0; i < serialMsgCnt; i++ {
-		b, _, err := lc.Msg()
+		b, _, err := c.Msg()
 		if err != nil {
 			atomic.AddInt64(&errCntGot, 1)
 		} else if len(b) > 0 {
@@ -417,7 +417,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 	// check the consumer stats again
 	tckr = time.NewTicker(time.Millisecond * 5)
 	<-tckr.C
-	stats = lc.consumer.Stats()
+	stats = c.consumer.Stats()
 
 	// messages finished
 	expected = 1 + serialMsgCnt
@@ -453,7 +453,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 			defer wg.Done()
 			<-releaseChan
 
-			b, _, err := lc.Msg()
+			b, _, err := c.Msg()
 			if err != nil {
 				atomic.AddInt64(&errCntGot, 1)
 			} else if len(b) > 0 {
@@ -483,7 +483,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 	// check the consumer stats again
 	tckr = time.NewTicker(time.Millisecond * 5)
 	<-tckr.C
-	stats = lc.consumer.Stats()
+	stats = c.consumer.Stats()
 
 	// messages finished
 	expected = 1 + pMsgCnt + serialMsgCnt
@@ -505,7 +505,7 @@ func TestLazyConsumer_Msg(t *testing.T) {
 
 	// check that consumer shuts down safely - even without
 	// successfully connecting
-	if err := lc.Stop(); err != nil {
+	if err := c.Stop(); err != nil {
 		t.Fatalf("bad shutdown: %v\n", err)
 	}
 

--- a/bus/nsq/nsq.go
+++ b/bus/nsq/nsq.go
@@ -6,9 +6,9 @@ import (
 	gonsq "github.com/bitly/go-nsq"
 )
 
-// Config is used for instantiating an NSQ Consumer or
+// Opt is used for instantiating an NSQ Consumer or
 // Producer. The Producer will ignore the Topic value.
-type Config struct {
+type Opt struct {
 	NSQdAddrs    []string // connects via TCP only
 	LookupdAddrs []string // connects via HTTP only
 

--- a/bus/nsq/producer.go
+++ b/bus/nsq/producer.go
@@ -11,12 +11,12 @@ import (
 	gonsq "github.com/bitly/go-nsq"
 )
 
-func NewProducer(c *Config) (*Producer, error) {
+func NewProducer(opt *Opt) (*Producer, error) {
 	// context for clean shutdown
 	ctx, cncl := context.WithCancel(context.Background())
 
 	p := &Producer{
-		conf:     c,
+		opt:      opt,
 		nsqConf:  gonsq.NewConfig(),
 		numConns: 1,
 		ctx:      ctx,
@@ -32,7 +32,7 @@ func NewProducer(c *Config) (*Producer, error) {
 }
 
 type Producer struct {
-	conf      *Config
+	opt       *Opt
 	nsqConf   *gonsq.Config
 	producers map[string]*gonsq.Producer
 	hostPool  hostpool.HostPool
@@ -52,7 +52,7 @@ type Producer struct {
 func (p *Producer) connect() error {
 	// make the producers
 	producers := make(map[string]*gonsq.Producer)
-	for _, host := range p.conf.NSQdAddrs {
+	for _, host := range p.opt.NSQdAddrs {
 		for i := 0; i < p.numConns; i++ {
 			producer, err := gonsq.NewProducer(host, p.nsqConf)
 			if err != nil {
@@ -60,8 +60,8 @@ func (p *Producer) connect() error {
 			}
 
 			// set custom logger
-			if p.conf.Logger != nil {
-				producer.SetLogger(p.conf.Logger, p.conf.LogLvl)
+			if p.opt.Logger != nil {
+				producer.SetLogger(p.opt.Logger, p.opt.LogLvl)
 			}
 
 			// check that producer has good host

--- a/bus/nsq/producer_test.go
+++ b/bus/nsq/producer_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestNewProducer(t *testing.T) {
-	conf := &Config{}
+	conf := &Opt{}
 	p, err := NewProducer(conf)
 
 	// err - not nil
@@ -26,7 +26,7 @@ func TestNewProducer(t *testing.T) {
 func TestProducer(t *testing.T) {
 	// connect with bad address
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	conf := &Opt{
 		NSQdAddrs: []string{"localhost:4000"},
 		Logger:    logger, // turn off nsq logging
 	}
@@ -43,7 +43,7 @@ func TestProducer(t *testing.T) {
 	}
 
 	// connect with good address
-	conf = &Config{
+	conf = &Opt{
 		NSQdAddrs: []string{"127.0.0.1:4150"},
 		Logger:    logger, // turn off nsq logging
 	}
@@ -85,7 +85,7 @@ func TestProducer(t *testing.T) {
 	}
 
 	// connect to multiple good nsqds
-	conf = &Config{
+	conf = &Opt{
 		NSQdAddrs: []string{"127.0.0.1:4150", "127.0.0.1:4150"},
 		Logger:    logger, // turn off nsq logging
 	}
@@ -105,7 +105,7 @@ func TestProducer(t *testing.T) {
 	}
 
 	// connect to multiple good nsqds - one good one bad
-	conf = &Config{
+	conf = &Opt{
 		NSQdAddrs: []string{"127.0.0.1:4150", "127.0.0.1:4000"},
 		Logger:    logger, // turn off nsq logging
 	}
@@ -127,7 +127,7 @@ func TestProducer_Race(t *testing.T) {
 	topic := "test-producer-topic"
 	msg := []byte("test message")
 	logger := log.New(ioutil.Discard, "", 0)
-	conf := &Config{
+	conf := &Opt{
 		NSQdAddrs: []string{"127.0.0.1:4150", "127.0.0.1:4150"},
 		Logger:    logger, // turn off nsq logging
 	}

--- a/launcher_test.go
+++ b/launcher_test.go
@@ -1,7 +1,1 @@
 package task
-
-//import "testing"
-//
-//func TestNewLauncher(t *testing.T) {
-//
-//}

--- a/quickstart/taskmaster/main.go
+++ b/quickstart/taskmaster/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 
 	"github.com/pcelvng/task"
-	"github.com/pcelvng/task/bus"
 )
 
 var (
@@ -15,7 +14,7 @@ var (
 func main() {
 	flag.Parse()
 
-	tskJson, _ := task.New(*tskType, *tskInfo).Bytes()
-	tskBus, _ := bus.NewBus(bus.NewBusConfig(""))
+	tskJson, _ := task.New(*tskType, *tskInfo).JSONBytes()
+	tskBus, _ := task.NewBus(task.NewBusOpt(""))
 	tskBus.Send("", tskJson)
 }

--- a/quickstart/worker/main.go
+++ b/quickstart/worker/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	l, _ := task.NewLauncherWBus(MakeWorker, nil)
+	l, _ := task.NewLauncher(MakeWorker, nil, nil)
 	ctx, _ := l.DoTasks()
 	<-ctx.Done()
 }

--- a/task.go
+++ b/task.go
@@ -114,8 +114,8 @@ func (t *Task) End(r Result, msg string) time.Time {
 	return t.ended
 }
 
-// Bytes returns the json bytes.
-func (t *Task) Bytes() ([]byte, error) {
+// JSONBytes returns the task json bytes.
+func (t *Task) JSONBytes() ([]byte, error) {
 	b, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
@@ -125,8 +125,8 @@ func (t *Task) Bytes() ([]byte, error) {
 }
 
 // String returns json string.
-func (t *Task) String() (string, error) {
-	b, err := t.Bytes()
+func (t *Task) JSONString() (string, error) {
+	b, err := t.JSONBytes()
 	if err != nil {
 		return "", err
 	}

--- a/task_test.go
+++ b/task_test.go
@@ -218,7 +218,7 @@ func TestTask_Bytes(t *testing.T) {
 	}
 
 	// should not have error
-	b, err := tsk.Bytes()
+	b, err := tsk.JSONBytes()
 	if err != nil {
 		t.Fatalf("task to bytes error: '%v'\n", err.Error())
 	}
@@ -284,7 +284,7 @@ func TestTask_Bytes(t *testing.T) {
 	tsk.Ended = tsStr
 
 	// no error
-	b, err = tsk.Bytes()
+	b, err = tsk.JSONBytes()
 	if err != nil {
 		t.Fatalf("task to bytes error: '%v'\n", err.Error())
 	}
@@ -345,7 +345,7 @@ func TestTask_String(t *testing.T) {
 		Info: "test-info",
 	}
 
-	tskStr, err := tsk.String()
+	tskStr, err := tsk.JSONString()
 	if err != nil {
 		t.Fatalf("task to string error: '%v'\n", err.Error())
 	}


### PR DESCRIPTION
- instead of 'config' language using 'opt' or 'options'
- removed some bus module methods that were not adding value and causing confusion.
- renamed some bus module util methods to add simplicity and clarity
- removed 'Bus' interface. Not necessary at this point and may never be necessary.
- changed interface 'Consumer' to 'ConsumerBus'
- changed interface 'Producer' to 'ProducerBus' 
- removed and renamed various task module initializer functions
- added bus utility wrapper functions in main task module so that for most cases the user will not need to import the 'bus' module. This way the user just imports the 'task' module. Simplifies user experience.
- added 'nop' producer and consumer for testing purposes.