### PR TITLE
Remove MakeWorker func

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -1,12 +1,31 @@
 package task
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type Worker interface {
 	// DoTask will return a Result and msg string.
-	DoTask(context.Context) (Result, string)
+	DoTask(ctx context.Context, info string) (Result, string)
 }
 
-// MakeWorker is called by the Launcher to
-// generate a new worker for a new task.
-type MakeWorker func(info string) Worker
+// IsDone is a helper function that determines if ctx has been canceled
+func IsDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+// Interrupted is a helper function that can be called when DoTask was interrupted
+func Interrupted() (Result, string) {
+	return ErrResult, "task interrupted"
+}
+
+// Completed is a helper function that can be called when DoTask has completed
+func Completed(format string, a ...interface{}) (Result, string) {
+	return CompleteResult, fmt.Sprintf(format, a)
+}


### PR DESCRIPTION
Can we simplify the worker interface by removing the requirement to have a new worker method and add the info string to DoTask?